### PR TITLE
chore: import repository https://github.com/jenkins-x-charts/nfs-subdir-external-provisioner.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -62,6 +62,7 @@ spec:
     - name: jx-bdd
     - name: knative-serving
     - name: local-external-secrets
+    - name: nfs-subdir-external-provisioner
     - name: pusher-wave
     - name: vault-instance
     scheduler: in-repo

--- a/config-root/namespaces/jx/grafana/grafana-deploy.yaml
+++ b/config-root/namespaces/jx/grafana/grafana-deploy.yaml
@@ -31,7 +31,7 @@ spec:
         checksum/config: 07078cb2807a66861efc4883db218f33765cafba04e5f6428536396dbc626d65
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: 0eabc13cf34514137466e96259a605e1e36841539be1be58ec83d48d56991bef
+        checksum/secret: c8247b66738a0d44d359d89f6d0cbe9fae1fe2ff436812e75b2c9616e6b129d9
     spec:
       serviceAccountName: grafana
       securityContext:

--- a/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
@@ -12,6 +12,7 @@ data:
         jenkins-x-charts/jx-bdd: true
         jenkins-x-charts/knative-serving: true
         jenkins-x-charts/local-external-secrets: true
+        jenkins-x-charts/nfs-subdir-external-provisioner: true
         jenkins-x-charts/pusher-wave: true
         jenkins-x-charts/vault-instance: true
         jenkins-x-labs-bdd-tests/godemo: true
@@ -138,6 +139,7 @@ data:
         jenkins-x-charts/jx-bdd: merge
         jenkins-x-charts/knative-serving: merge
         jenkins-x-charts/local-external-secrets: merge
+        jenkins-x-charts/nfs-subdir-external-provisioner: merge
         jenkins-x-charts/pusher-wave: merge
         jenkins-x-charts/vault-instance: merge
         jenkins-x-images/kaniko: merge
@@ -214,6 +216,7 @@ data:
         - jenkins-x-charts/jx-bdd
         - jenkins-x-charts/knative-serving
         - jenkins-x-charts/local-external-secrets
+        - jenkins-x-charts/nfs-subdir-external-provisioner
         - jenkins-x-charts/pusher-wave
         - jenkins-x-charts/vault-instance
         - jenkins-x/feature-infra-secrets
@@ -287,6 +290,7 @@ data:
         - jenkins-x-charts/jx-bdd
         - jenkins-x-charts/knative-serving
         - jenkins-x-charts/local-external-secrets
+        - jenkins-x-charts/nfs-subdir-external-provisioner
         - jenkins-x-charts/pusher-wave
         - jenkins-x-charts/vault-instance
         - jenkins-x/feature-infra-secrets

--- a/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
@@ -36,6 +36,10 @@ data:
       require_self_approval: true
     - lgtm_acts_as_approve: true
       repos:
+      - jenkins-x-charts/nfs-subdir-external-provisioner
+      require_self_approval: true
+    - lgtm_acts_as_approve: true
+      repos:
       - jenkins-x-charts/pusher-wave
       require_self_approval: true
     - lgtm_acts_as_approve: true
@@ -353,6 +357,22 @@ data:
       - dog
       - pony
       jenkins-x-charts/local-external-secrets:
+      - approve
+      - assign
+      - blunderbuss
+      - help
+      - hold
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - trigger
+      - wip
+      - heart
+      - cat
+      - dog
+      - pony
+      jenkins-x-charts/nfs-subdir-external-provisioner:
       - approve
       - assign
       - blunderbuss
@@ -1329,6 +1349,9 @@ data:
       trusted_org: todo
     - repos:
       - jenkins-x-charts/local-external-secrets
+      trusted_org: todo
+    - repos:
+      - jenkins-x-charts/nfs-subdir-external-provisioner
       trusted_org: todo
     - repos:
       - jenkins-x-charts/pusher-wave

--- a/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: jx
   annotations:
     wave.pusher.com/update-on-config-change: 'true'
-    jenkins-x.io/hash: '423517cb3e66a95d5219178cab334c71227c212b9a27976d8be7c213e1135aa0'
+    jenkins-x.io/hash: 'd02e7f9042b382f13ea6f0fe3280eba2db4c91d464f6f330149d383016f46711'
 spec:
   replicas: 1
   selector:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: jx
   annotations:
     wave.pusher.com/update-on-config-change: 'true'
-    jenkins-x.io/hash: '423517cb3e66a95d5219178cab334c71227c212b9a27976d8be7c213e1135aa0'
+    jenkins-x.io/hash: 'd02e7f9042b382f13ea6f0fe3280eba2db4c91d464f6f330149d383016f46711'
 spec:
   replicas: 1
   strategy:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: jx
   annotations:
     wave.pusher.com/update-on-config-change: 'true'
-    jenkins-x.io/hash: '423517cb3e66a95d5219178cab334c71227c212b9a27976d8be7c213e1135aa0'
+    jenkins-x.io/hash: 'd02e7f9042b382f13ea6f0fe3280eba2db4c91d464f6f330149d383016f46711'
 spec:
   replicas: 1
   selector:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     checksum/config: 1e3e9e8f57ec5d14cc8afbe2943108aba0c029d1a274c2f1823b4310c1b2381b
     wave.pusher.com/update-on-config-change: 'true'
-    jenkins-x.io/hash: '423517cb3e66a95d5219178cab334c71227c212b9a27976d8be7c213e1135aa0'
+    jenkins-x.io/hash: 'd02e7f9042b382f13ea6f0fe3280eba2db4c91d464f6f330149d383016f46711'
   namespace: jx
 spec:
   replicas: 1

--- a/config-root/namespaces/jx/source-repositories/jenkins-x-charts-nfs-subdir-external-provisioner.yaml
+++ b/config-root/namespaces/jx/source-repositories/jenkins-x-charts-nfs-subdir-external-provisioner.yaml
@@ -1,0 +1,22 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: jenkins-x-charts
+    provider: github
+    repository: nfs-subdir-external-provisioner
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  name: jenkins-x-charts-nfs-subdir-external-provisioner
+  namespace: jx
+spec:
+  httpCloneURL: https://github.com/jenkins-x-charts/nfs-subdir-external-provisioner.git
+  org: jenkins-x-charts
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: nfs-subdir-external-provisioner
+  scheduler:
+    kind: ""
+    name: in-repo
+  url: https://github.com/jenkins-x-charts/nfs-subdir-external-provisioner


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges