### PR TITLE
chore: promote sdm-agent-kubernetes to version 0.4.0

### DIFF
--- a/helmfiles/sdm/helmfile.yaml
+++ b/helmfiles/sdm/helmfile.yaml
@@ -7,9 +7,11 @@ namespace: sdm
 repositories:
 - name: labs
   url: https://storage.googleapis.com/jx-labs-infra-charts/charts
+- name: dev
+  url: http://chartmuseum-jx.35.242.181.72.nip.io/
 releases:
 - chart: labs/sdm-agent-kubernetes
-  version: 0.4.1
+  version: 0.4.0
   name: sdm-agent-kubernetes
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote sdm-agent-kubernetes to version 0.4.0

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
